### PR TITLE
Fix deprecated GitHub workflow actions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run tests
         if: ${{ vars.ACTIONS_STEP_DEBUG != 'true' }}

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -64,7 +64,7 @@ jobs:
           verbose: ${{ vars.ACTIONS_STEP_DEBUG == 'true' }}
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: target/tarpaulin/clio-auth-coverage.json

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -40,15 +40,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-          default: true
-          components: rustfmt, clippy
-
       - name: Install Tarpaulin
         run: cargo install cargo-tarpaulin
 
@@ -66,10 +57,11 @@ jobs:
         run: cargo tarpaulin --out XML
 
       - name: Upload coverage to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+          verbose: ${{ vars.ACTIONS_STEP_DEBUG == 'true' }}
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Upgrades the following actions:
1. `actions/checkout`
2. `actions/upload-artifact`
3. `codecov/codecov-action`

Also, removes usage of `actions-rs/toolchain`

Fixes: #19 