### PR TITLE
fix: escape error messages in HTML response to prevent XSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Latent XSS vulnerability in the default error response of the OAuth helper server by HTML-escaping error messages.
+- `youtube` example incorrectly requested a write scope and lacked documentation for demo credentials.
+
+## [1.0.0] - 2026-06-23
+
+### Added
+- `CliOAuthBuilder::open_browser(bool)` to allow suppressing automatic browser launch.
+- Integration tests for the local callback server (happy path, timeout, error handling).
+
+### Changed
+- **BREAKING**: Upgraded `oauth2` to v5.0.0, requiring updates to client configuration and generic parameters.
+- **BREAKING**: `CliOAuth::authorize` now returns the authorization `Url`.
+- Examples now use `oauth2::reqwest::Client` for token exchange to match the v5 API.
+
+### Fixed
+- Callback server now correctly returns HTTP 400 when authorization query parameters are missing.
 
 ## [0.9.0] - 2026-06-22
 
@@ -92,7 +107,8 @@ Initial release.
 
 <!-- next-url -->
 [Unreleased]: https://github.com/riversoforion/clio-auth/compare/v1.0.1...HEAD
-[1.0.1]: https://github.com/riversoforion/clio-auth/compare/v0.9.0...v1.0.1
+[1.0.1]: https://github.com/riversoforion/clio-auth/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/riversoforion/clio-auth/compare/v0.9.0...v1.0.0
 [0.9.0]: https://github.com/riversoforion/clio-auth/compare/v0.8.0...v0.9.0
 [0.8.1]: https://github.com/riversoforion/clio-auth/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/riversoforion/clio-auth/compare/v0.7.1...v0.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-26
+
+### Fixed
+- Latent XSS vulnerability in the default error response of the OAuth helper server by HTML-escaping error messages.
+
 ## [0.9.0] - 2026-06-22
 
 ### Added
@@ -86,7 +91,8 @@ Initial release.
 - CI pipeline with multi-platform builds and code coverage
 
 <!-- next-url -->
-[Unreleased]: https://github.com/riversoforion/clio-auth/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/riversoforion/clio-auth/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/riversoforion/clio-auth/compare/v0.9.0...v1.0.1
 [0.9.0]: https://github.com/riversoforion/clio-auth/compare/v0.8.0...v0.9.0
 [0.8.1]: https://github.com/riversoforion/clio-auth/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/riversoforion/clio-auth/compare/v0.7.1...v0.8.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "clio-auth"
 description = "OAuth 2 helper library for CLI and desktop applications"
 authors = ["Eric McIntyre <mac@riversoforion.com>"]
 license = "MIT"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 repository = "https://github.com/riversoforion/clio-auth"
 documentation = "https://docs.rs/clio-auth"
@@ -28,6 +28,7 @@ tokio = { version = "1.52.3", features = [
 poem = "3.1.12"
 url = "2.5.8"
 thiserror = "2.0.18"
+html-escape = "0.2.14"
 
 [dev-dependencies]
 rstest = "0.26.1"

--- a/src/server.rs
+++ b/src/server.rs
@@ -109,12 +109,14 @@ fn default_ok_response() -> impl IntoResponse {
 }
 
 async fn default_error_response(error: Error) -> impl IntoResponse {
+    let error_text = format!("{error}");
+    let escaped_error = html_escape::encode_safe(&error_text);
     let content = format!(
         r"
     <html>
         <h1 style='color: red'>Error!</h1>
         <p>There was an error authenticating. Please try again.</p>
-        <p>Details: {error}</p>
+        <p>Details: {escaped_error}</p>
     </html>
     ",
     );
@@ -280,5 +282,20 @@ mod tests {
         let content = body.into_string().await.unwrap();
         assert!(content.contains("Error!"));
         assert!(content.contains("Details: Internal server error"));
+    }
+
+    #[tokio::test]
+    async fn default_error_response_escapes_html() {
+        let xss_payload = "<script>alert('xss')</script>";
+        let error = Error::from_string(xss_payload, StatusCode::BAD_REQUEST);
+        let response = default_error_response(error).await.into_response();
+        let body = response.into_body();
+        let content = body.into_string().await.unwrap();
+
+        assert!(
+            !content.contains(xss_payload),
+            "XSS payload should be escaped"
+        );
+        assert!(content.contains("&lt;script&gt;alert(&#x27;xss&#x27;)&lt;&#x2F;script&gt;"));
     }
 }


### PR DESCRIPTION
This PR fixes a latent XSS vulnerability by HTML-escaping error messages before rendering them in the default error response.

Fixes: #40