### PR TITLE
fix: Use constant time comparison for CSRF token

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,14 @@ categories = ["authentication", "command-line-interface"]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [dependencies]
+constant_time_eq = "0.5.0"
+html-escape = "0.2.15"
 log = "0.4.33"
 oauth2 = "5.0.0"
 open = "5.4.1"
+poem = "3.1.12"
 serde = "1.0.229"
+thiserror = "2.0.20"
 tokio = { version = "1.53.1", features = [
   "rt-multi-thread",
   "sync",
@@ -25,15 +29,12 @@ tokio = { version = "1.53.1", features = [
   "macros",
   "signal",
 ] }
-poem = "3.1.12"
 url = "2.5.8"
-thiserror = "2.0.20"
-html-escape = "0.2.15"
 
 [dev-dependencies]
-rstest = "0.26.1"
 pretty_env_logger = "0.5.0"
 reqwest = { version = "0.13.4", features = ["json"] }
+rstest = "0.26.1"
 serde = { version = "1.0.229", features = ["derive"] }
 
 [[example]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,8 +236,8 @@ impl CliOAuth {
 
     /// Validates the authorization code and CSRF token (`state`).
     ///
-    /// If validation is successful, then the code and PKCE verifier are returned to the caller in
-    /// order to build the [exchange code](oauth2::Client::exchange_code) request.
+    /// If validation is successful, then the code and PKCE verifier are returned to the caller
+    /// to build the [exchange code](oauth2::Client::exchange_code) request.
     ///
     /// This method *must* be called after [`CliOAuth::authorize`] completes successfully.
     pub fn validate(&mut self) -> Result<AuthContext, AuthError> {
@@ -484,6 +484,51 @@ mod tests {
                 Err(e) => panic!("CsrfMismatch error should be raised, but was {:?}", e),
                 Ok(_) => panic!("Validation should fail"),
             };
+        }
+
+        #[rstest]
+        #[tokio::test]
+        async fn authorize_success() {
+            use oauth2::basic::BasicClient;
+            use oauth2::{AuthUrl, ClientId};
+            use std::time::Duration;
+
+            let mut auth = CliOAuth::builder()
+                .port_range(18000..18001)
+                .timeout(5)
+                .open_browser(false)
+                .build()
+                .unwrap();
+            let client = BasicClient::new(ClientId::new("client".into()))
+                .set_auth_uri(AuthUrl::new("http://auth".into()).unwrap());
+
+            let addr = auth.address;
+
+            let auth_handle = tokio::spawn(async move {
+                let res = auth.authorize(&client).await;
+                (res, auth)
+            });
+
+            // Give the server a moment to start
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            let resp = reqwest::get(format!("http://{}?code=my_code&state=any_state", addr))
+                .await
+                .expect("Failed to send callback");
+            assert!(resp.status().is_success());
+
+            let (res, auth) = auth_handle.await.unwrap();
+            let auth_url = res.expect("authorize failed");
+
+            assert!(auth_url.as_str().starts_with("http://auth"));
+
+            // Verify internal state
+            let auth_context = auth.auth_context.expect("auth_context should be set");
+            assert_eq!(auth_context.auth_code.secret(), "my_code");
+
+            let auth_result = auth.auth_result.expect("auth_result should be set");
+            assert_eq!(auth_result.auth_code, "my_code");
+            assert_eq!(auth_result.state, "any_state");
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,6 +459,23 @@ mod tests {
         }
 
         #[rstest]
+        fn validate_success(
+            mut auth: CliOAuth,
+            auth_result: AuthorizationResult,
+            auth_context: AuthContext,
+        ) {
+            auth.auth_result = Some(auth_result);
+            auth.auth_context = Some(auth_context);
+
+            let res = auth.validate();
+            assert!(res.is_ok());
+            let ctx = res.unwrap();
+            assert_eq!(ctx.auth_code.secret(), "code");
+            assert_eq!(ctx.state.secret(), "state");
+            assert_eq!(ctx.pkce_verifier.secret(), "pkce");
+        }
+
+        #[rstest]
         fn validate_with_no_context(mut auth: CliOAuth, auth_result: AuthorizationResult) {
             auth.auth_result = Some(auth_result);
             assert!(auth.validate().is_err());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@
 //! [1]: https://www.rfc-editor.org/rfc/rfc7636
 //! [2]: https://crates.io/crates/oauth2
 
+use constant_time_eq::constant_time_eq;
 use std::fmt::{Debug, Formatter};
 use std::net::{IpAddr, SocketAddr, TcpListener};
 use std::ops::Range;
@@ -246,7 +247,14 @@ impl CliOAuth {
             .ok_or(AuthError::InvalidAuthState)?
             .state;
         match self.auth_context.take() {
-            Some(auth_ctx) if auth_ctx.state.secret() == &expected_state => Ok(auth_ctx),
+            Some(auth_ctx)
+                if constant_time_eq(
+                    auth_ctx.state.secret().as_bytes(),
+                    expected_state.as_bytes(),
+                ) =>
+            {
+                Ok(auth_ctx)
+            }
             Some(_) => Err(AuthError::CsrfMismatch),
             None => Err(AuthError::InvalidAuthState),
         }


### PR DESCRIPTION
Updated the comparison of the CSRF state token against the provided value to use a constant time equality algorithm.

Fixes: #42