### PR TITLE
fix: Use GitHub app for release-plz action

### DIFF
--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -22,7 +22,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
+
       - name: Run release-plz
         uses: MarcoIeni/release-plz-action@v0.5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          client-id: ${{ vars.RELEASE_PLZ_APP_CLIENT_ID }}
+          client-id: ${{ secrets.RELEASE_PLZ_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
 
       - name: Run release-plz

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -2,7 +2,8 @@ name: Release Please
 
 on:
   push:
-    branches: [main]
+    branches: [main, fix/issue-39-release-plz]
+  workflow_dispatch: # Also allows manual triggering from Actions UI / CLI
 
 permissions:
   contents: write

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -24,10 +24,10 @@ jobs:
           fetch-depth: 0
 
       - name: Create GitHub App Token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ vars.RELEASE_PLZ_APP_ID }}
+          client-id: ${{ vars.RELEASE_PLZ_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
 
       - name: Run release-plz

--- a/.github/workflows/release-plz.yaml
+++ b/.github/workflows/release-plz.yaml
@@ -2,7 +2,7 @@ name: Release Please
 
 on:
   push:
-    branches: [main, fix/issue-39-release-plz]
+    branches: [main]
   workflow_dispatch: # Also allows manual triggering from Actions UI / CLI
 
 permissions:


### PR DESCRIPTION
Installed a GitHub App to allow `release-plz` to run workflows on its PRs.

Fixes: #39